### PR TITLE
Fix "numpy.ndarray has no attribute getA1" errors

### DIFF
--- a/dev/petri.py
+++ b/dev/petri.py
@@ -186,7 +186,7 @@ class Petri:
         if pre:
             if self._repr_mode == Petri.DENSE:
                 subnet = self._pre_matrix.take(list(transitions), axis=1)
-                places |= set(subnet.nonzero()[0].getA1())
+                places |= set(np.ravel(subnet.nonzero()[0]))
             elif self._repr_mode == Petri.SPARSE:
                 for t in transitions:
                     places |= set(self._pre_matrix.getcol(t).nonzero()[0])
@@ -194,7 +194,7 @@ class Petri:
         if post:
             if self._repr_mode == Petri.DENSE:
                 subnet = self._post_matrix.take(list(transitions), axis=1)
-                places |= set(subnet.nonzero()[0].getA1())
+                places |= set(np.ravel(subnet.nonzero()[0]))
             elif self._repr_mode == Petri.SPARSE:
                 for t in transitions:
                     places |= set(self._post_matrix.getcol(t).nonzero()[0])
@@ -215,8 +215,8 @@ class Petri:
 
         if pre:
             if self._repr_mode == Petri.DENSE:
-                subnet = self._post_matrix.take(list(places), axis=0)
-                transitions |= set(subnet.nonzero()[1].getA1())
+                subnet = self._post_matrix.take(list(places), axis=0)        
+                transitions |= set(np.ravel(subnet.nonzero()[1]))
             elif self._repr_mode == Petri.SPARSE:
                 for p in places:
                     transitions |= set(self._post_matrix.getrow(p).nonzero()[1])
@@ -224,7 +224,7 @@ class Petri:
         if post:
             if self._repr_mode == Petri.DENSE:
                 subnet = self._pre_matrix.take(list(places), axis=0)
-                transitions |= set(subnet.nonzero()[1].getA1())
+                transitions |= set(np.ravel(subnet.nonzero()[1]))
             elif self._repr_mode == Petri.SPARSE:
                 for p in places:
                     transitions |= set(self._pre_matrix.getrow(p).nonzero()[1])

--- a/stable/petri.py
+++ b/stable/petri.py
@@ -301,7 +301,7 @@ def transitions_set(petrinet, places, reverse=False, pre=False, post=False):
     if pre:
         if config.representation_mode == config.DENSE:
             subnet      = post_matrix.take(list(places), axis=0)
-            transitions = transitions | set(subnet.nonzero()[1].getA1())
+            transitions |= set(np.ravel(subnet.nonzero()[1]))
         elif config.representation_mode == config.SPARSE:
             for p in places:
                 transitions |= set(post_matrix.getrow(p).nonzero()[1])
@@ -309,7 +309,7 @@ def transitions_set(petrinet, places, reverse=False, pre=False, post=False):
     if post:
         if config.representation_mode == config.DENSE:
             subnet      = pre_matrix.take(list(places), axis=0)
-            transitions = transitions | set(subnet.nonzero()[1].getA1())
+            transitions |= set(np.ravel(subnet.nonzero()[1]))
         elif config.representation_mode == config.SPARSE:
             for p in places:
                 transitions |= set(pre_matrix.getrow(p).nonzero()[1])

--- a/stable/petri.py
+++ b/stable/petri.py
@@ -270,7 +270,7 @@ def places_set(petrinet, transitions, reverse=False, pre=False, post=False):
     if pre:
         if config.representation_mode == config.DENSE:
             subnet = pre_matrix.take(list(transitions), axis=1)
-            places = places | set(subnet.nonzero()[0].getA1())
+            places |= set(np.ravel(subnet.nonzero()[0]))
         elif config.representation_mode == config.SPARSE:
             for t in transitions:
                 places = places | set(pre_matrix.getcol(t).nonzero()[0])
@@ -278,7 +278,7 @@ def places_set(petrinet, transitions, reverse=False, pre=False, post=False):
     if post:
         if config.representation_mode == config.DENSE:
             subnet = post_matrix.take(list(transitions), axis=1)
-            places = places | set(subnet.nonzero()[0].getA1())
+            places |= set(np.ravel(subnet.nonzero()[0]))
         elif config.representation_mode == config.SPARSE:
             for t in transitions:
                 places = places | set(post_matrix.getcol(t).nonzero()[0])


### PR DESCRIPTION
Using np.asarray(x).ravel() to flatten ndarray, cf https://docs.scipy.org/doc/numpy/reference/generated/numpy.matrix.A1.html